### PR TITLE
Web view

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Each university in the list displays:
 - Country
 - Website (if available)
 
+### 5. In-App Web View
+
+When you tap on a university's website link, it opens within the app using an integrated web view, providing a seamless browsing experience without leaving the app.
+
 
 ![University Details](https://github.com/Qharny/EduAtlas/blob/main/Assets/images/example.jpg?raw=true)
 
@@ -55,6 +59,7 @@ EduAtlas uses the following key components:
 2. **University Model**: Structures the data received from the API.
 3. **Onboarding Screen**: Uses the `introduction_screen` package for a smooth onboarding experience.
 4. **Home Screen**: Implements a custom UI with a search bar and results list.
+5. **Web View**: Uses `webview_flutter` package for in-app web browsing.
 
 ## Getting Started
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="EduAtlas"
         android:name="${applicationName}"

--- a/lib/screens/web_view_screen.dart
+++ b/lib/screens/web_view_screen.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+class WebViewScreen extends StatefulWidget {
+  final String url;
+  final String title;
+
+  const WebViewScreen({
+    super.key,
+    required this.url,
+    required this.title,
+  });
+
+  @override
+  State<WebViewScreen> createState() => _WebViewScreenState();
+}
+
+class _WebViewScreenState extends State<WebViewScreen> {
+  late final WebViewController _controller;
+  bool _isLoading = true;
+  String _currentUrl = '';
+  bool _canGoBack = false;
+  bool _canGoForward = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeWebView();
+  }
+
+  void _initializeWebView() {
+    String cleanUrl = widget.url.trim();
+    if (!cleanUrl.startsWith('http://') && !cleanUrl.startsWith('https://')) {
+      cleanUrl = 'https://$cleanUrl';
+    }
+
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onProgress: (int progress) {
+            // Update loading bar based on WebView loading progress
+          },
+          onPageStarted: (String url) {
+            setState(() {
+              _isLoading = true;
+              _currentUrl = url;
+            });
+          },
+          onPageFinished: (String url) async {
+            setState(() {
+              _isLoading = false;
+              _currentUrl = url;
+            });
+            
+            // Check navigation state
+            _canGoBack = await _controller.canGoBack();
+            _canGoForward = await _controller.canGoForward();
+            setState(() {});
+          },
+          onWebResourceError: (WebResourceError error) {
+            // Handle web resource errors
+            if (mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('Error loading page: ${error.description}'),
+                  backgroundColor: Colors.red,
+                ),
+              );
+            }
+          },
+        ),
+      )
+      ..loadRequest(Uri.parse(cleanUrl));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      appBar: AppBar(
+        title: Text(
+          widget.title,
+          style: const TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 18,
+          ),
+        ),
+        backgroundColor: Theme.of(context).appBarTheme.backgroundColor,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: _canGoBack ? () async {
+              if (await _controller.canGoBack()) {
+                await _controller.goBack();
+              }
+            } : null,
+          ),
+          IconButton(
+            icon: const Icon(Icons.arrow_forward),
+            onPressed: _canGoForward ? () async {
+              if (await _controller.canGoForward()) {
+                await _controller.goForward();
+              }
+            } : null,
+          ),
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () {
+              _controller.reload();
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.open_in_new),
+            onPressed: () async {
+              // Fallback to external browser
+              try {
+                final Uri url = Uri.parse(_currentUrl.isNotEmpty ? _currentUrl : widget.url);
+                await launchUrl(url, mode: LaunchMode.externalApplication);
+              } catch (e) {
+                if (mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Unable to open in external browser'),
+                      backgroundColor: Colors.red,
+                    ),
+                  );
+                }
+              }
+            },
+          ),
+        ],
+        bottom: _isLoading
+            ? PreferredSize(
+                preferredSize: const Size.fromHeight(2),
+                child: LinearProgressIndicator(
+                  backgroundColor: Colors.transparent,
+                  valueColor: AlwaysStoppedAnimation<Color>(
+                    Theme.of(context).primaryColor,
+                  ),
+                ),
+              )
+            : null,
+      ),
+      body: Column(
+        children: [
+          if (_isLoading)
+            Container(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      valueColor: AlwaysStoppedAnimation<Color>(
+                        Theme.of(context).primaryColor,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      'Loading...',
+                      style: TextStyle(
+                        color: Theme.of(context).textTheme.bodyMedium?.color,
+                        fontSize: 14,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          Expanded(
+            child: WebViewWidget(controller: _controller),
+          ),
+        ],
+      ),
+    );
+  }
+} 

--- a/lib/utils/url_launcher_utils.dart
+++ b/lib/utils/url_launcher_utils.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../screens/web_view_screen.dart';
 import '../widgets/common/custom_snackbar.dart';
 
 class UrlLauncherUtils {
@@ -15,55 +16,71 @@ class UrlLauncherUtils {
         cleanUrl = 'https://$cleanUrl';
       }
 
-      final Uri url = Uri.parse(cleanUrl);
-
-      try {
-        final bool launched = await launchUrl(
-          url,
-          mode: LaunchMode.externalApplication,
-        );
-        if (!launched) {
-          throw 'Launch returned false';
-        }
-      } catch (e) {
-        try {
-          await launchUrl(url, mode: LaunchMode.inAppBrowserView);
-        } catch (e2) {
-          await launchUrl(url);
-        }
-      }
-    } catch (e) {
+      // Navigate to in-app web view
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: const Row(
-              children: [
-                Icon(Icons.link_off, color: Colors.white),
-                SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    'Unable to open link. Please check your connection.',
-                  ),
-                ),
-              ],
-            ),
-            backgroundColor: Colors.orange.shade600,
-            behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(12),
-            ),
-            margin: const EdgeInsets.all(16),
-            action: SnackBarAction(
-              label: 'Copy URL',
-              textColor: Colors.white,
-              onPressed: () {
-                Clipboard.setData(ClipboardData(text: urlString));
-                CustomSnackBar.showSuccess(context, 'URL copied to clipboard');
-              },
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => WebViewScreen(
+              url: cleanUrl,
+              title: _extractDomainName(cleanUrl),
             ),
           ),
         );
       }
+    } catch (e) {
+      // Fallback to external browser if in-app web view fails
+      try {
+        final Uri url = Uri.parse(urlString);
+        await launchUrl(url, mode: LaunchMode.externalApplication);
+      } catch (fallbackError) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: const Row(
+                children: [
+                  Icon(Icons.link_off, color: Colors.white),
+                  SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Unable to open link. Please check your connection.',
+                    ),
+                  ),
+                ],
+              ),
+              backgroundColor: Colors.orange.shade600,
+              behavior: SnackBarBehavior.floating,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              margin: const EdgeInsets.all(16),
+              action: SnackBarAction(
+                label: 'Copy URL',
+                textColor: Colors.white,
+                onPressed: () {
+                  Clipboard.setData(ClipboardData(text: urlString));
+                  CustomSnackBar.showSuccess(
+                    context,
+                    'URL copied to clipboard',
+                  );
+                },
+              ),
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  static String _extractDomainName(String url) {
+    try {
+      final uri = Uri.parse(url);
+      String domain = uri.host;
+      if (domain.startsWith('www.')) {
+        domain = domain.substring(4);
+      }
+      return domain;
+    } catch (e) {
+      return 'Website';
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -190,6 +190,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.4"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -240,6 +245,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.4"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   introduction_screen:
     dependency: "direct main"
     description:
@@ -280,6 +293,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  localization:
+    dependency: "direct main"
+    description:
+      name: localization
+      sha256: "9fa21644b75ca3fe844f8f115d03cd6fdc675054dd9aab6c5de5861145ea57b5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -621,6 +621,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      sha256: c3e4fe614b1c814950ad07186007eff2f2e5dd2935eba7b9a9a1af8e5885f1ba
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.0"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: "9a25f6b4313978ba1c2cda03a242eea17848174912cfb4d2d8ee84a556f248e3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.1"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "63d26ee3aca7256a83ccb576a50272edd7cfc80573a4305caa98985feb493ee0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.14.0"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: fb46db8216131a3e55bcf44040ca808423539bc6732e7ed34fb6d8044e3d512f
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.23.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -647,4 +679,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.27.0"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,10 @@ dependencies:
   webview_flutter: ^4.7.0
   gif: ^2.3.0
   flutter_launcher_icons: ^0.14.4
+  localization: ^2.1.1
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.20.2
 
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   introduction_screen: ^3.1.14
   shared_preferences: ^2.2.3
   url_launcher: ^6.3.0
+  webview_flutter: ^4.7.0
   gif: ^2.3.0
   flutter_launcher_icons: ^0.14.4
 


### PR DESCRIPTION
This pull request adds an in-app web view feature to the application, allowing users to browse university websites directly within the app for a more seamless experience. It introduces a new `WebViewScreen`, updates the URL launching logic to prioritize in-app browsing, and documents the new functionality and dependencies.

**In-App Web View Integration:**

* Added a new `WebViewScreen` (`lib/screens/web_view_screen.dart`) that uses the `webview_flutter` package to display university websites within the app, complete with navigation controls, loading indicators, and error handling.
* Updated `UrlLauncherUtils` (`lib/utils/url_launcher_utils.dart`) to route website links to the in-app web view by default, with a fallback to the external browser if needed. Also added a utility to extract the domain name for display. [[1]](diffhunk://#diff-aabb566a3e112b71355eb9ca74e57d1e79e3d78d27fda0f43c7c4c3f92eca7eaR5) [[2]](diffhunk://#diff-aabb566a3e112b71355eb9ca74e57d1e79e3d78d27fda0f43c7c4c3f92eca7eaL18-R35) [[3]](diffhunk://#diff-aabb566a3e112b71355eb9ca74e57d1e79e3d78d27fda0f43c7c4c3f92eca7eaR73-R86)
* Added the `webview_flutter` dependency to `pubspec.yaml`.

**Permissions and Documentation:**

* Added the `INTERNET` permission to the Android manifest to support web browsing.
* Updated the `README.md` to document the new in-app web view feature and its implementation details. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R47-R50) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62)

These changes collectively enhance the user experience by allowing seamless in-app browsing of university websites.